### PR TITLE
Add undefined check for event.key and some additional unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.0
+### Added
+* Destroy method on Shortcuts
+### Changed
+* Fixed issue with Shortcuts handler erroring when receiving an event with no key value (browser bug)
+
 ## 1.2.1
 ### Changed
 * Inline sourcemaps

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "keysy-peasy",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keysy-peasy",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Really simple, centralized shortcut management.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/classes/Shortcuts.ts
+++ b/src/classes/Shortcuts.ts
@@ -7,13 +7,21 @@ import { KeysyPeasyError } from "./KeasyPeasyError";
 export class Shortcuts {
 
     private _shortcuts: IShortcutMap = {};
+    private _element: HTMLElement;
+    private readonly _keyDownHandler: (event) => void;
 
     constructor(element: HTMLElement = document.documentElement) {
-        element.addEventListener("keydown", this._debounce(this._handler.bind(this)));
+        this._element = element;
+        this._keyDownHandler = this._debounce(this._handler.bind(this))
+        this._element.addEventListener("keydown", this._keyDownHandler);
     }
 
     private _handler(event: KeyboardEvent): void {
-        const shortcut = this._shortcuts[event.key.toString().toLowerCase()];
+        if(event.key === undefined){
+            return;
+        }
+
+        const shortcut = this._shortcuts[event.key.toLowerCase()];
 
         if (shortcut !== undefined && event.altKey === !!shortcut.altKey) {
             shortcut.callback(event);
@@ -52,5 +60,10 @@ export class Shortcuts {
                 delete this._shortcuts[key];
             }
         }
+    }
+
+    public destroy(): void {
+        this._shortcuts = {};
+        this._element.removeEventListener("keydown", this._keyDownHandler);
     }
 }

--- a/src/tests/Shortcuts.spec.ts
+++ b/src/tests/Shortcuts.spec.ts
@@ -168,7 +168,7 @@ describe('When using keysy peasy', () => {
         });
 
         describe("and no shortcut is registered for the event's key", () => {
-            test("it should trigger the callback", () => {
+            test("it should not trigger the callback", () => {
                 document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {"key": "g", bubbles: true, altKey: true}));
                 jest.runAllTimers();
                 expect(callback).not.toBeCalled();

--- a/src/tests/Shortcuts.spec.ts
+++ b/src/tests/Shortcuts.spec.ts
@@ -1,11 +1,10 @@
 import { Shortcuts } from "../classes/Shortcuts";
-import { KeysyPeasyError } from "..";
+import { KeysyPeasyError } from "../classes/KeasyPeasyError";
 
-Object.defineProperty(document, "addEventListener", (event: string, callback: () => void) => {});
-
-describe('When registering events', () => {
-    const shortcuts = new Shortcuts(document.documentElement);
-    const callback = () => {};
+describe('When using keysy peasy', () => {
+    jest.useFakeTimers();
+    let shortcuts: Shortcuts;
+    const callback = jest.fn();
 
     const domainTestId = "domain test";
     const firstTestId = "first test";
@@ -35,37 +34,81 @@ describe('When registering events', () => {
         altKey:false
     };
 
-    shortcuts.register(firstTestId, [exampleShortcut1, exampleShortcut2]);
-    shortcuts.register(secondTestId, [exampleShortcut3]);
+    beforeEach(() => {
+        shortcuts = new Shortcuts(document.documentElement);
+    })
 
-    test('it should correctly initialise the shortcut', () => {
-        shortcuts.register(domainTestId, [exampleShortcut]);
-        const shortcut = shortcuts.getHandlers()[exampleShortcut.key];
-        expect(shortcut.key).toEqual(exampleShortcut.key);
-        expect(shortcut.contextId).toEqual(domainTestId);
-        expect(shortcut.altKey).toEqual(exampleShortcut.altKey);
-        expect(shortcut.callback).toEqual(exampleShortcut.callback);
-    });
+    afterEach(() => {
+        callback.mockReset();
+        shortcuts.destroy();
+    })
 
-    test("it should not let you register two of the same shortcut", () => {
-        expect(() => shortcuts.register("random-id", [exampleShortcut]))
-            .toThrow(new KeysyPeasyError("Duplicate shortcut", exampleShortcut));
-    });
+    describe("and registering events", () => {
+        beforeEach(() => {
+            shortcuts.register(firstTestId, [exampleShortcut1, exampleShortcut2]);
+            shortcuts.register(secondTestId, [exampleShortcut3]);
+        })
 
-    test('it should correctly register events with different Ids', () => {
-        const shortcutMap = shortcuts.getHandlers();
-        expect(shortcutMap[exampleShortcut1.key]).toBeDefined();
-        expect(shortcutMap[exampleShortcut2.key]).toBeDefined();
-        expect(shortcutMap[exampleShortcut3.key]).toBeDefined();
-    });
+        test('it should correctly initialise the shortcut', () => {
+            shortcuts.register(domainTestId, [exampleShortcut]);
+            const shortcut = shortcuts.getHandlers()[exampleShortcut.key];
+            expect(shortcut.key).toEqual(exampleShortcut.key);
+            expect(shortcut.contextId).toEqual(domainTestId);
+            expect(shortcut.altKey).toEqual(exampleShortcut.altKey);
+            expect(shortcut.callback).toEqual(exampleShortcut.callback);
+        });
 
-    describe('and an event is removed', () => {
-        test('it should remove events by domain id', () => {
-            shortcuts.remove(firstTestId);
+        test("it should not let you register two of the same shortcut", () => {
+            shortcuts.register(domainTestId, [exampleShortcut]);
+            expect(() => shortcuts.register("random-id", [exampleShortcut]))
+                .toThrow(new KeysyPeasyError("Duplicate shortcut", exampleShortcut));
+        });
+
+        test('it should correctly register events with different Ids', () => {
             const shortcutMap = shortcuts.getHandlers();
-            expect(shortcutMap[exampleShortcut1.key]).toBeUndefined();
-            expect(shortcutMap[exampleShortcut2.key]).toBeUndefined();
+            expect(shortcutMap[exampleShortcut1.key]).toBeDefined();
+            expect(shortcutMap[exampleShortcut2.key]).toBeDefined();
             expect(shortcutMap[exampleShortcut3.key]).toBeDefined();
+        });
+
+        describe('and an event is removed', () => {
+            test('it should remove events by domain id', () => {
+                shortcuts.remove(firstTestId);
+                const shortcutMap = shortcuts.getHandlers();
+                expect(shortcutMap[exampleShortcut1.key]).toBeUndefined();
+                expect(shortcutMap[exampleShortcut2.key]).toBeUndefined();
+                expect(shortcutMap[exampleShortcut3.key]).toBeDefined();
+            });
+        });
+    });
+
+    describe("and an event occurs", () => {
+        beforeEach(() => {
+            shortcuts.register(secondTestId, [exampleShortcut3]);
+        });
+
+        describe("and a shortcut is registered for the events key", () => {
+            test("it should trigger the callback", () => {
+                document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {"key": "p", bubbles: true}));
+                jest.runAllTimers();
+                expect(callback).toBeCalledTimes(1)
+            });
+        });
+
+        describe("and no shortcut is registered for the events key", () => {
+            test("it should trigger the callback", () => {
+                document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {"key": "g", bubbles: true}));
+                jest.runAllTimers();
+                expect(callback).not.toBeCalled();
+            });
+        });
+
+        describe("and the key is undefined", () => {
+            test("it should not run the callback", () => {
+                document.documentElement.dispatchEvent(new KeyboardEvent("keydown"));
+                jest.runAllTimers();
+                expect(callback).not.toBeCalled();
+            });
         });
     });
 });

--- a/src/tests/Shortcuts.spec.ts
+++ b/src/tests/Shortcuts.spec.ts
@@ -82,12 +82,12 @@ describe('When using keysy peasy', () => {
         });
     });
 
-    describe("and an event occurs", () => {
+    describe("and an event occurs without a modifier", () => {
         beforeEach(() => {
-            shortcuts.register(secondTestId, [exampleShortcut3]);
+            shortcuts.register(firstTestId, [exampleShortcut3]);
         });
 
-        describe("and a shortcut is registered for the events key", () => {
+        describe("and a shortcut is registered for the event's key", () => {
             test("it should trigger the callback", () => {
                 document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {"key": "p", bubbles: true}));
                 jest.runAllTimers();
@@ -95,7 +95,28 @@ describe('When using keysy peasy', () => {
             });
         });
 
-        describe("and no shortcut is registered for the events key", () => {
+        describe("and a shortcut is removed for the event's key", () => {
+            test("it should not trigger the callback once removed", () => {
+                document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {"key": "p", bubbles: true}));
+                jest.runAllTimers();
+                shortcuts.remove(firstTestId);
+                document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {"key": "p", bubbles: true}));
+                jest.runAllTimers();
+                expect(callback).toBeCalledTimes(1);
+            });
+        });
+
+        describe("and a shortcut is removed for the event's key before the debounce", () => {
+            test("it should not trigger the callback", () => {
+                document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {"key": "p", bubbles: true}));
+                shortcuts.remove(firstTestId);
+                document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {"key": "p", bubbles: true}));
+                jest.runAllTimers();
+                expect(callback).toBeCalledTimes(0);
+            });
+        });
+
+        describe("and no shortcut is registered for the event's key", () => {
             test("it should trigger the callback", () => {
                 document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {"key": "g", bubbles: true}));
                 jest.runAllTimers();
@@ -106,6 +127,57 @@ describe('When using keysy peasy', () => {
         describe("and the key is undefined", () => {
             test("it should not run the callback", () => {
                 document.documentElement.dispatchEvent(new KeyboardEvent("keydown"));
+                jest.runAllTimers();
+                expect(callback).not.toBeCalled();
+            });
+        });
+    });
+
+    describe("and an event occurs with a modifier", () => {
+        beforeEach(() => {
+            shortcuts.register(firstTestId, [exampleShortcut2]);
+        });
+
+        describe("and a shortcut is registered for the event's key", () => {
+            test("it should trigger the callback", () => {
+                document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {"key": "f", bubbles: true, altKey: true}));
+                jest.runAllTimers();
+                expect(callback).toBeCalledTimes(1)
+            });
+        });
+
+        describe("and a shortcut is removed for the event's key", () => {
+            test("it should not trigger the callback once removed", () => {
+                document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {"key": "f", bubbles: true, altKey: true}));
+                jest.runAllTimers();
+                shortcuts.remove(firstTestId);
+                document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {"key": "f", bubbles: true, altKey: true}));
+                jest.runAllTimers();
+                expect(callback).toBeCalledTimes(1);
+            });
+        });
+
+        describe("and a shortcut is removed for the event's key before the debounce", () => {
+            test("it should not trigger the callback", () => {
+                document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {"key": "f", bubbles: true, altKey: true}));
+                shortcuts.remove(firstTestId);
+                document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {"key": "f", bubbles: true, altKey: true}));
+                jest.runAllTimers();
+                expect(callback).toBeCalledTimes(0);
+            });
+        });
+
+        describe("and no shortcut is registered for the event's key", () => {
+            test("it should trigger the callback", () => {
+                document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {"key": "g", bubbles: true, altKey: true}));
+                jest.runAllTimers();
+                expect(callback).not.toBeCalled();
+            });
+        });
+
+        describe("and the key is undefined", () => {
+            test("it should not run the callback", () => {
+                document.documentElement.dispatchEvent(new KeyboardEvent("keydown", {altKey: true}));
                 jest.runAllTimers();
                 expect(callback).not.toBeCalled();
             });


### PR DESCRIPTION
This PR adds an undefined check around the event.key in handler within Shortcuts.ts as some events seemingly slip through without a key being present.

Also added additional unit tests to ensure the callback is fired in the correct circumstances.